### PR TITLE
Fix image size problem by including archie-lsp-all.jar only once

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     // This dependency is used by the application.
     implementation 'com.google.guava:guava:31.0.1-jre'
 
-    implementation 'com.nedap.healthcare.archie:archie-all:2.0.0'
+    implementation('com.nedap.healthcare.archie:archie-all:2.0.1')
     implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0'
     implementation 'org.slf4j:slf4j-nop:1.7.36'
 
@@ -65,25 +65,7 @@ test {
     // Use junit platform for unit tests
     useJUnitPlatform()
 }
-//
-//graal {
-//    outputName 'archetype-lsp'
-//    mainClass 'com.nedap.openehr.lsp.App'
-//    javaVersion '11'
-//    option '--no-fallback'
-//    option '-H:IncludeResources=.*\\.(bmm|arp)'
-//    graalVersion '20.1.0'
-//}
-//jar {
-//    manifest {
-//        attributes(
-//                'Main-Class': 'com.nedap.openehr.lsp.App'
-//        )
-//    }
-//    from {
-//        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-//    }
-//}
+
 task buildExtension() {
     dependsOn build
 
@@ -116,7 +98,7 @@ runtime {
     targetPlatform('linux-x64', jvm_linux_home)
     targetPlatform('winx64', jvm_windows_home)
     targetPlatform('macos-x64', jvm_macos_x86_home)
-    targetPlatform('macos-arm64', jvm_macos_arm_home)
+  //  targetPlatform('macos-arm64', jvm_macos_arm_home)
     launcher {
         jvmArgs = ['--add-opens', 'java.base/java.lang=ALL-UNNAMED'
                    , '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED'

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,9 @@ runtime {
     targetPlatform('macos-x64', jvm_macos_x86_home)
     targetPlatform('macos-arm64', jvm_macos_arm_home)
     launcher {
+        //To set the classpath to the single included jar file, instead of one per distribution, the start scripts
+        //are customized. Taken from https://github.com/beryx/badass-runtime-plugin/blob/master/src/main/resources/
+        //and only the CLASSPATH is changed to point at APP_HOME/../app/* to pick up the archie-lsp-all.jar
         unixScriptTemplate = file("$projectDir/unixScriptTemplate.txt")
         windowsScriptTemplate = file("$projectDir/windowsScriptTemplate.txt")
         jvmArgs = ['--add-opens', 'java.base/java.lang=ALL-UNNAMED'

--- a/build.gradle
+++ b/build.gradle
@@ -70,11 +70,27 @@ task buildExtension() {
     dependsOn build
 
     doLast {
+        mkdir "$projectDir/build/image/app"
+
+        //now copy it all to the vscode extension dir
         delete "$projectDir/vscode-extension/lsp-images"
+
         copy {
             from "$projectDir/build/image"
             into "$projectDir/vscode-extension/lsp-images"
         }
+
+        //copy the jar file to a common directory so it does not get included multiple times
+        copy {
+            from "$projectDir/vscode-extension/lsp-images/archie-lsp-macos-x64/lib/archie-lsp-all.jar"
+            into "$projectDir/vscode-extension/lsp-images/app"
+        }
+        //then remove all the other jar files to save space. The custom start script template will fix the classpath
+        delete "$projectDir/vscode-extension/lsp-images/archie-lsp-macos-x64/lib/archie-lsp-all.jar"
+        delete "$projectDir/vscode-extension/lsp-images/archie-lsp-macos-arm64/lib/archie-lsp-all.jar"
+        delete "$projectDir/vscode-extension/lsp-images/archie-lsp-linux-x64/lib/archie-lsp-all.jar"
+        delete "$projectDir/vscode-extension/lsp-images/archie-lsp-winx64/lib/archie-lsp-all.jar"
+
         exec {
             workingDir "$projectDir/vscode-extension"
             commandLine "npm", "install"
@@ -98,8 +114,10 @@ runtime {
     targetPlatform('linux-x64', jvm_linux_home)
     targetPlatform('winx64', jvm_windows_home)
     targetPlatform('macos-x64', jvm_macos_x86_home)
-  //  targetPlatform('macos-arm64', jvm_macos_arm_home)
+    targetPlatform('macos-arm64', jvm_macos_arm_home)
     launcher {
+        unixScriptTemplate = file("$projectDir/unixScriptTemplate.txt")
+        windowsScriptTemplate = file("$projectDir/windowsScriptTemplate.txt")
         jvmArgs = ['--add-opens', 'java.base/java.lang=ALL-UNNAMED'
                    , '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED'
                    , '--add-opens', 'java.base/java.net=ALL-UNNAMED'

--- a/unixScriptTemplate.txt
+++ b/unixScriptTemplate.txt
@@ -1,0 +1,162 @@
+#!/usr/bin/env sh
+
+##############################################################################
+##
+##  ${applicationName} start up script for UN*X
+##
+##############################################################################
+
+# Attempt to set APP_HOME
+# Resolve links: \$0 may be a link
+PRG="\$0"
+# Need this for relative symlinks.
+while [ -h "\$PRG" ] ; do
+    ls=`ls -ld "\$PRG"`
+    link=`expr "\$ls" : '.*-> \\(.*\\)\$'`
+    if expr "\$link" : '/.*' > /dev/null; then
+        PRG="\$link"
+    else
+        PRG=`dirname "\$PRG"`"/\$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"\$PRG\"`/${appHomeRelativePath}" >/dev/null
+APP_HOME="`pwd -P`"
+cd "\$SAVED" >/dev/null
+
+APP_NAME="${applicationName}"
+APP_BASE_NAME=`basename "\$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
+DEFAULT_JVM_OPTS=${defaultJvmOpts}
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn () {
+    echo "\$*"
+}
+
+die () {
+    echo
+    echo "\$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
+
+CLASSPATH="\$APP_HOME/lib/*:\$APP_HOME/../app/*"
+
+JAVA_HOME="\$APP_HOME"
+JAVACMD="\$JAVA_HOME/bin/java"
+
+# Increase the maximum file descriptors if we can.
+if [ "\$cygwin" = "false" -a "\$darwin" = "false" -a "\$nonstop" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ \$? -eq 0 ] ; then
+        if [ "\$MAX_FD" = "maximum" -o "\$MAX_FD" = "max" ] ; then
+            MAX_FD="\$MAX_FD_LIMIT"
+        fi
+        ulimit -n \$MAX_FD
+        if [ \$? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: \$MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: \$MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if \$darwin; then
+    GRADLE_OPTS="\$GRADLE_OPTS \\"-Xdock:name=\$APP_NAME\\" \\"-Xdock:icon=\$APP_HOME/media/gradle.icns\\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if \$cygwin ; then
+    APP_HOME=`cygpath --path --mixed "\$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "\$CLASSPATH"`
+    JAVA_HOME="\$APP_HOME"
+    JAVACMD="\$JAVA_HOME/bin/java"
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in \$ROOTDIRSRAW ; do
+        ROOTDIRS="\$ROOTDIRS\$SEP\$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^(\$ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "\$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="\$OURCYGPATTERN|(\$GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "\$@" ; do
+        CHECK=`echo "\$arg"|egrep -c "\$OURCYGPATTERN" -`
+        CHECK2=`echo "\$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ \$CHECK -ne 0 ] && [ \$CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args\$i`=`cygpath --path --ignore --mixed "\$arg"`
+        else
+            eval `echo args\$i`="\"\$arg\""
+        fi
+        i=\$((i+1))
+    done
+    case \$i in
+        (0) set -- ;;
+        (1) set -- "\$args0" ;;
+        (2) set -- "\$args0" "\$args1" ;;
+        (3) set -- "\$args0" "\$args1" "\$args2" ;;
+        (4) set -- "\$args0" "\$args1" "\$args2" "\$args3" ;;
+        (5) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" ;;
+        (6) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" "\$args5" ;;
+        (7) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" "\$args5" "\$args6" ;;
+        (8) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" "\$args5" "\$args6" "\$args7" ;;
+        (9) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" "\$args5" "\$args6" "\$args7" "\$args8" ;;
+    esac
+fi
+
+# Escape application args
+save () {
+    for i do printf %s\\\\n "\$i" | sed "s/'/'\\\\\\\\''/g;1s/^/'/;\\\$s/\\\$/' \\\\\\\\/" ; done
+    echo " "
+}
+APP_ARGS=\$(save "\$@")
+
+<% if ( System.properties['BADASS_CDS_ARCHIVE_FILE_LINUX'] ) { %>
+CDS_ARCHIVE_FILE="<%= System.properties['BADASS_CDS_ARCHIVE_FILE_LINUX'] %>"
+CDS_JVM_OPTS="-XX:ArchiveClassesAtExit=\$CDS_ARCHIVE_FILE"
+if [ -f "\$CDS_ARCHIVE_FILE" ]; then
+    CDS_JVM_OPTS="-XX:SharedArchiveFile=\$CDS_ARCHIVE_FILE"
+fi
+<% } %>
+
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- \$DEFAULT_JVM_OPTS \$CDS_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar} <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %>-classpath "\"\$CLASSPATH\"" ${mainClassName} "\$APP_ARGS"
+
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [ "\$(uname)" = "Darwin" ] && [ "\$HOME" = "\$PWD" ]; then
+  cd "\$(dirname "\$0")"
+fi
+
+<% if ( System.properties['BADASS_RUN_IN_BIN_DIR'] ) { %>cd "\$APP_HOME/bin" && <% } %>exec "\$JAVACMD" "\$@"

--- a/vscode-extension/client/src/extension.ts
+++ b/vscode-extension/client/src/extension.ts
@@ -47,10 +47,10 @@ export function activate(context: ExtensionContext) {
     } else if(process.platform == 'darwin' && process.arch == 'arm64') {
          serverOptions = {
              run: {
-                 command: path.join(context.extensionPath , 'lsp-images', 'archie-lsp-macos-x64', 'bin', 'archie-lsp')
+                 command: path.join(context.extensionPath , 'lsp-images', 'archie-lsp-macos-arm64', 'bin', 'archie-lsp')
              },
              debug: {
-                 command: path.join(context.extensionPath , 'lsp-images', 'archie-lsp-macos-x64', 'bin', 'archie-lsp')
+                 command: path.join(context.extensionPath , 'lsp-images', 'archie-lsp-macos-arm64', 'bin', 'archie-lsp')
              }
          };
      }

--- a/vscode-extension/client/src/extension.ts
+++ b/vscode-extension/client/src/extension.ts
@@ -47,10 +47,10 @@ export function activate(context: ExtensionContext) {
     } else if(process.platform == 'darwin' && process.arch == 'arm64') {
          serverOptions = {
              run: {
-                 command: path.join(context.extensionPath , 'lsp-images', 'archie-lsp-macos-arm64', 'bin', 'archie-lsp')
+                 command: path.join(context.extensionPath , 'lsp-images', 'archie-lsp-macos-x64', 'bin', 'archie-lsp')
              },
              debug: {
-                 command: path.join(context.extensionPath , 'lsp-images', 'archie-lsp-macos-arm64', 'bin', 'archie-lsp')
+                 command: path.join(context.extensionPath , 'lsp-images', 'archie-lsp-macos-x64', 'bin', 'archie-lsp')
              }
          };
      }
@@ -64,7 +64,7 @@ export function activate(context: ExtensionContext) {
             }
         };
     } else {
-        throw 'unsupported platform, this extension only runs on windows, macos or linux on x86 CPUs: ' + process.platform
+        throw 'unsupported platform, this extension only runs on windows, macos or linux on x86 CPUs, plus mac os on ARM CPUs: ' + process.platform
     }
     
     let clientOptions: LanguageClientOptions = {

--- a/windowsScriptTemplate.txt
+++ b/windowsScriptTemplate.txt
@@ -1,0 +1,76 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  ${applicationName} startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%${appHomeRelativePath}
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=${defaultJvmOpts}
+
+set JAVA_HOME="%APP_HOME%"
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+set JAVA_EXE="%JAVA_EXE:"=%"
+
+if exist %JAVA_EXE% goto init
+
+echo.
+echo ERROR: The directory %JAVA_HOME% does not contain a valid Java runtime for your platform.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH="%JAVA_HOME:"=%/lib/*;%JAVA_HOME:"=%/../app/archie-lsp-all.jar"
+
+<% if ( System.properties['BADASS_CDS_ARCHIVE_FILE_WINDOWS'] ) { %>
+set CDS_ARCHIVE_FILE="<%= System.properties['BADASS_CDS_ARCHIVE_FILE_WINDOWS'] %>"
+set CDS_JVM_OPTS=-XX:ArchiveClassesAtExit=%CDS_ARCHIVE_FILE%
+if exist %CDS_ARCHIVE_FILE% set CDS_JVM_OPTS=-XX:SharedArchiveFile=%CDS_ARCHIVE_FILE%
+<% } %>
+
+@rem Execute ${applicationName}
+<% if ( System.properties['BADASS_RUN_IN_BIN_DIR'] ) { %>pushd %DIRNAME% & <% } %>%JAVA_EXE% %DEFAULT_JVM_OPTS% %CDS_JVM_OPTS% %JAVA_OPTS% %${optsEnvironmentVar}% <% if ( appNameSystemProperty ) { %>"-D${appNameSystemProperty}=%APP_BASE_NAME%"<% } %> -classpath %CLASSPATH% ${mainClassName} %CMD_LINE_ARGS%<% if ( System.properties['BADASS_RUN_IN_BIN_DIR'] ) { %> & popd<% } %>
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable ${exitEnvironmentVar} if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%${exitEnvironmentVar}%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega


### PR DESCRIPTION
Previously, each runtime, for windows, linux, mac x64 and mac arm included the archie-lsp-all.jar file.

Now that a fourth JVM is added, the VSIX file is too big for the marketplace.

this PR moves it to a single included archie-lsp-all.jar file, saving about 90-95MB.

It does so by:
- creating a standard runtime, with custom start scripts which have a custom classpath, pointing to `../app/*`
- copying it to the vscode-extension folder
- copying the jar file to a separate directory called `app` in the lsp-images directory
- removing the four separate jar files from the four runtimes

Tested on mac x64, mac arm64, linux x64 and windows x64, and it works on all platforms.