### PR TITLE
upgrade LSP library to 0.14.0, revert workaround for https://github.c…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'com.google.guava:guava:31.0.1-jre'
 
     implementation('com.nedap.healthcare.archie:archie-all:2.0.1')
-    implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0'
+    implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.14.0'
     implementation 'org.slf4j:slf4j-nop:1.7.36'
 
     implementation 'com.nedap.healthcare:aqlparser:*'

--- a/src/main/java/com/nedap/openehr/lsp/App.java
+++ b/src/main/java/com/nedap/openehr/lsp/App.java
@@ -34,25 +34,7 @@ public class App {
         OutputStream out = System.out;
 
         ADL2LanguageServer server = new ADL2LanguageServer();
-        Launcher<LanguageClient> launcher =  new LSPLauncher.Builder<LanguageClient>()
-                .setLocalService(server)
-                .setRemoteInterface(LanguageClient.class)
-                .setInput(in)
-                .setOutput(out)
-                .configureGson(gsonBuilder -> {
-                    gsonBuilder.registerTypeAdapter(
-                            SemanticTokensCapabilities.class,
-                            new InstanceCreator<SemanticTokensCapabilities>() {
-
-                                @Override
-                                public SemanticTokensCapabilities createInstance(Type type) {
-                                    return new SemanticTokensCapabilities(null);
-                                }
-                            }
-                    );
-                })
-                .create();
-        //Launcher<LanguageClient> launcher = LSPLauncher.createServerLauncher(server, in, out);
+        Launcher<LanguageClient> launcher = LSPLauncher.createServerLauncher(server, in, out);
         server.connect(launcher.getRemoteProxy(), launcher.getRemoteEndpoint());
 
         launcher.startListening();
@@ -71,25 +53,7 @@ public class App {
                                 OutputStream out = socket.getOutputStream();
 
                                 ADL2LanguageServer server = new ADL2LanguageServer();
-                                Launcher<LanguageClient> launcher =  new LSPLauncher.Builder<LanguageClient>()
-                                        .setLocalService(server)
-                                        .setRemoteInterface(LanguageClient.class)
-                                        .setInput(in)
-                                        .setOutput(out)
-                                        .configureGson(gsonBuilder -> {
-                                            gsonBuilder.registerTypeAdapter(
-                                                    SemanticTokensCapabilities.class,
-                                                    new InstanceCreator<SemanticTokensCapabilities>() {
-
-                                                        @Override
-                                                        public SemanticTokensCapabilities createInstance(Type type) {
-                                                            return new SemanticTokensCapabilities(null);
-                                                        }
-                                                    }
-                                            );
-                                        })
-                                        .create();
-                                //Launcher<LanguageClient> launcher = LSPLauncher.createServerLauncher(server, in, out);
+                                Launcher<LanguageClient> launcher = LSPLauncher.createServerLauncher(server, in, out);
                                 server.connect(launcher.getRemoteProxy(), launcher.getRemoteEndpoint());
 
 


### PR DESCRIPTION
As https://github.c)om/eclipse/lsp4j/issues/601 was fixed, upgrading to version 0.14.0 of eclipse-lsp makes it possible to remove the workaround for that issue.

