### PR TITLE
Fix overlay validations not appearing

### DIFF
--- a/src/main/java/com/nedap/openehr/lsp/document/DocumentInformation.java
+++ b/src/main/java/com/nedap/openehr/lsp/document/DocumentInformation.java
@@ -5,16 +5,9 @@ import com.nedap.archie.paths.PathSegment;
 import com.nedap.archie.query.APathQuery;
 import com.nedap.openehr.lsp.paths.ArchetypePathReference;
 import com.nedap.openehr.lsp.utils.DocumentSymbolUtils;
-import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.DocumentLink;
-import org.eclipse.lsp4j.DocumentSymbol;
-import org.eclipse.lsp4j.FoldingRange;
-import org.eclipse.lsp4j.Hover;
-import org.eclipse.lsp4j.HoverParams;
-import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
-import javax.swing.text.Document;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/src/main/java/com/nedap/openehr/lsp/document/DocumentInformation.java
+++ b/src/main/java/com/nedap/openehr/lsp/document/DocumentInformation.java
@@ -14,8 +14,8 @@ import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
-import java.util.ArrayList;
-import java.util.List;
+import javax.swing.text.Document;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -43,15 +43,22 @@ public class DocumentInformation {
     private final CodeRangeIndex<DocumentSymbol> cTerminologyCodes;
     /** all path references in rules */
     private final List<ArchetypePathReference> modelReferences;
+    private final Map<String, DocumentSymbol> templateOverlays;
 
     public DocumentInformation(String archetypeId, ADLVersion adlVersion, ANTLRParserErrors errors,
                                List<Either<SymbolInformation, DocumentSymbol>> symbols,
                                List<FoldingRange> foldingRanges,
                                List<DocumentLink> documentLinks) {
-        this(archetypeId, adlVersion, errors, symbols, foldingRanges, documentLinks, new CodeRangeIndex<>(), new ArrayList<>());
+        this(archetypeId, adlVersion, errors, symbols, foldingRanges, documentLinks, new CodeRangeIndex<>(), new ArrayList<>(), new LinkedHashMap<>());
     }
 
-    public DocumentInformation(String archetypeId, ADLVersion adlVersion, ANTLRParserErrors errors, List<Either<SymbolInformation, DocumentSymbol>> symbols, List<FoldingRange> foldingRanges, List<DocumentLink> documentLinks, CodeRangeIndex<DocumentSymbol> cTerminologyCodes, List<ArchetypePathReference> modelReferences) {
+    public DocumentInformation(String archetypeId, ADLVersion adlVersion, ANTLRParserErrors errors,
+                               List<Either<SymbolInformation, DocumentSymbol>> symbols,
+                               List<FoldingRange> foldingRanges,
+                               List<DocumentLink> documentLinks,
+                               CodeRangeIndex<DocumentSymbol> cTerminologyCodes,
+                               List<ArchetypePathReference> modelReferences,
+                               Map<String, DocumentSymbol> templateOverlays) {
         this.archetypeId = archetypeId;
         this.adlVersion = adlVersion;
         this.errors = errors;
@@ -60,6 +67,7 @@ public class DocumentInformation {
         this.documentLinks = new DocumentLinks(documentLinks);
         this.cTerminologyCodes = cTerminologyCodes;
         this.modelReferences = modelReferences;
+        this.templateOverlays = templateOverlays;
     }
 
     public String getArchetypeId() {
@@ -122,20 +130,59 @@ public class DocumentInformation {
 
     private static final Pattern cComplexObjectPattern = Pattern.compile("(?<type>.*)\\[(?<code>.*)\\]");
 
-
+    /**
+     * Archetype path lookup. Definition only for now. Returns a result higher up the tree if it cannot be found
+     *
+     * @param path the path to lookup
+     * @return the DocumentSymbol corresponding with the given CObject or CAttribute
+     */
     public DocumentSymbol lookupCObjectOrAttribute(String path) {
         return lookupCObjectOrAttribute(path, true);
     }
 
     /**
      * Archetype path lookup. Definition only for now. Sorry for the ugly code, but this works rather well :)
-     * @param path
-     * @return
+     * @param path the path to lookup
+     * @param returnResultSoFar if true, if the path cannot be found, return a DocumentSymbol higher up the tree so the syntax
+     *                         highlighting is as close as possible. If false, in that case returns null
+     * @return the DocumentSymbol corresponding with the given CObject or CAttribute
      */
     public DocumentSymbol lookupCObjectOrAttribute(String path, boolean returnResultSoFar) {
+        List<DocumentSymbol> documentSymbols = DocumentSymbolUtils.getDocumentSymbols(symbols);
+        return lookupCObjectOrAttribute(path, returnResultSoFar, documentSymbols);
+    }
+
+    /**
+     * Archetype path lookup. Definition only for now.
+     * @param templateOverlayId the archetype id of the template overlay
+     * @param path the path to lookup
+     * @param returnResultSoFar if true, if the path cannot be found, return a DocumentSymbol higher up the tree so the syntax
+     *                         highlighting is as close as possible. If false, in that case returns null
+     * @return the DocumentSymbol corresponding with the given CObject or CAttribute
+     */
+    public DocumentSymbol lookupCObjectOrAttributeInOverlay(String templateOverlayId,
+                                                            String path,
+                                                            boolean returnResultSoFar) {
+        DocumentSymbol documentSymbol = getTemplateOverlayRootSymbol(templateOverlayId);
+        if(documentSymbol == null) {
+            return null;
+        }
+        return lookupCObjectOrAttribute(path, returnResultSoFar, Collections.singletonList(documentSymbol));
+    }
+
+    /**
+     * Archetype path lookup in a given list of DocumentSymbols. Inner method for use in root or template overlay.
+     * @param path the path to lookup
+     * @param returnResultSoFar if true, if the path cannot be found, return a DocumentSymbol higher up the tree so the syntax
+     *                         highlighting is as close as possible. If false, in that case returns null
+     * @param documentSymbols the list of symbols to start performing the lookup in (usually only one symbol).
+     * @return the DocumentSymbol corresponding with the given CObject or CAttribute
+     */
+    private DocumentSymbol lookupCObjectOrAttribute(String path,
+                                                   boolean returnResultSoFar,
+                                                   List<DocumentSymbol> documentSymbols) {
         APathQuery query = new APathQuery(path);
         List<PathSegment> pathSegments = query.getPathSegments();
-        List<DocumentSymbol> documentSymbols = DocumentSymbolUtils.getDocumentSymbols(symbols);
 
         if(documentSymbols.isEmpty()) {
             return null;
@@ -269,11 +316,28 @@ public class DocumentInformation {
         return returnResultSoFar ? currentSymbol : null;
     }
 
+    /**
+     * finds the root symbol of a given template overlay id
+     * @param templateOverlayId the template overlay archetype id to search for
+     * @return the root DocumentSymbol of the template overlay, or null if it cannot be found
+     */
+    public DocumentSymbol getTemplateOverlayRootSymbol(String templateOverlayId) {
+        return templateOverlays.get(templateOverlayId);
+    }
+
     public CodeRangeIndex<DocumentSymbol> getcTerminologyCodes() {
         return cTerminologyCodes;
     }
 
     public List<ArchetypePathReference> getModelReferences() {
         return modelReferences;
+    }
+
+    public ADLVersion getAdlVersion() {
+        return adlVersion;
+    }
+
+    public Map<String, DocumentSymbol> getTemplateOverlays() {
+        return templateOverlays;
     }
 }

--- a/src/main/java/com/nedap/openehr/lsp/symbolextractor/ADL2SymbolExtractor.java
+++ b/src/main/java/com/nedap/openehr/lsp/symbolextractor/ADL2SymbolExtractor.java
@@ -38,7 +38,8 @@ public class ADL2SymbolExtractor {
                 symbolExtractingListener.getFoldingRanges(),
                 symbolExtractingListener.getDocumentLinks(),
                 symbolExtractingListener.getCTerminologyCodes(),
-                symbolExtractingListener.getModelReferences());
+                symbolExtractingListener.getModelReferences(),
+                symbolExtractingListener.getTemplateOverlays());
     }
 
     public String getArchetypeId() {

--- a/src/main/java/com/nedap/openehr/lsp/symbolextractor/DocumentSymbolStack.java
+++ b/src/main/java/com/nedap/openehr/lsp/symbolextractor/DocumentSymbolStack.java
@@ -39,7 +39,8 @@ public class DocumentSymbolStack {
     }
 
     public void addSymbol(TerminalNode node, ParserRuleContext entireRule, String tokenName, SymbolKind symbolKind, StackAction stackAction) {
-
+        //TODO: is this visitedTokens check still necessary? To confirm, needs extensive manual testing.
+        //after that, return the added symbol from this method, as it can be used instead of peek() in at least one occurrence
         if(!this.visitedTokens.contains(node.getSymbol())) {
             DocumentSymbol symbol = createSymbolInformation(tokenName, symbolKind, createRange(node.getSymbol()));
 

--- a/src/main/java/com/nedap/openehr/lsp/symbolextractor/SymbolInformationExtractingListener.java
+++ b/src/main/java/com/nedap/openehr/lsp/symbolextractor/SymbolInformationExtractingListener.java
@@ -50,6 +50,8 @@ public class SymbolInformationExtractingListener extends AdlBaseListener {
 
     private String currentOverlayid;
 
+    private Map<String, DocumentSymbol> templateOverlays = new LinkedHashMap<>();
+
     public SymbolInformationExtractingListener(String documentUri, AdlLexer lexer) {
         this.documentUri = documentUri;
     }
@@ -136,7 +138,9 @@ public class SymbolInformationExtractingListener extends AdlBaseListener {
 
     @Override public void enterTemplateOverlay(AdlParser.TemplateOverlayContext ctx) {
         stack.addSymbol(ctx.SYM_TEMPLATE_OVERLAY(), ctx, "archetype", SymbolKind.Constant, StackAction.PUSH);
+        DocumentSymbol templateSymbol = stack.peek();
         stack.addSymbol(ctx.ARCHETYPE_HRID(), "archetype id", SymbolKind.Class);
+        templateOverlays.put(ctx.ARCHETYPE_HRID().getText(), templateSymbol);
         addFoldingRange(ctx.getStart().getLine(), ctx); //starts with \n, which shouldn't be in result
         setOverlayId(ctx.ARCHETYPE_HRID());
     }
@@ -543,5 +547,9 @@ public class SymbolInformationExtractingListener extends AdlBaseListener {
 
     public List<ArchetypePathReference> getModelReferences() {
         return modelReferences;
+    }
+
+    public Map<String, DocumentSymbol> getTemplateOverlays() {
+        return templateOverlays;
     }
 }

--- a/src/test/java/com/nedap/openehr/lsp/BasicTest.java
+++ b/src/test/java/com/nedap/openehr/lsp/BasicTest.java
@@ -1,12 +1,8 @@
 package com.nedap.openehr.lsp;
 
-import com.nedap.openehr.lsp.document.DocumentInformation;
-import com.nedap.openehr.lsp.utils.DocumentSymbolUtils;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.lsp4j.services.TextDocumentService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -14,34 +10,30 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class BasicTest extends LanguageServerTestBase {
 
-
-
     @Test
     public void testBasics() throws IOException {
-
         openResource("test_archetype.adls");
-        System.out.println(testClient.getDiagnostics());
-        assertTrue(testClient.getDiagnostics().get("uri").getDiagnostics().isEmpty());
+        Supplier<String> messageSupplier = () -> testClient.getDiagnostics().toString();
+        assertTrue(testClient.getDiagnostics().get("uri").getDiagnostics().isEmpty(), messageSupplier);
     }
 
     @Test
     public void syntaxError() throws IOException {
-
         openResource("syntax_error.adls");
-        System.out.println(testClient.getDiagnostics());
+
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get("uri").getDiagnostics();
         assertFalse(diagnostics.isEmpty());
         Diagnostic diagnostic = diagnostics.get(0);
-        assertEquals("ADL2 syntax", diagnostic.getSource());
-        assertEquals(new Position(17, 18), diagnostic.getRange().getStart());
-        assertEquals(new Position(17, 53), diagnostic.getRange().getEnd());
-        assertTrue(diagnostic.getMessage().contains("matchess"));
+        assertEquals("ADL2 syntax", diagnostic.getSource(), diagnosticsMessageSupplier);
+        assertEquals(new Position(17, 18), diagnostic.getRange().getStart(), diagnosticsMessageSupplier);
+        assertEquals(new Position(17, 53), diagnostic.getRange().getEnd(), diagnosticsMessageSupplier);
+        assertTrue(diagnostic.getMessage().contains("matchess"), diagnosticsMessageSupplier);
     }
 
     /**
@@ -52,21 +44,21 @@ public class BasicTest extends LanguageServerTestBase {
     public void templateErrorInDefinition() throws IOException {
         openResource("test_archetype.adls");
         openResource("template_definition_error_in_ovl.adlt");
-        System.out.println(testClient.getDiagnostics());
+
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get("uri").getDiagnostics();
         assertFalse(diagnostics.isEmpty());
         //the error that one of the template overlay validations failed
-        Diagnostic prettyMuchUselessError = diagnostics.get(0);
-        assertEquals("ADL validation", prettyMuchUselessError.getSource());
-        assertEquals(new Position(25, 4), prettyMuchUselessError.getRange().getStart());
-        assertEquals(new Position(25, 11), prettyMuchUselessError.getRange().getEnd());
-        assertTrue(prettyMuchUselessError.getMessage().contains("The validation of a template overlay failed"));
+        Diagnostic templateError = diagnostics.get(0);
+        assertEquals("ADL validation", templateError.getSource(), diagnosticsMessageSupplier);
+        assertEquals(new Position(25, 4), templateError.getRange().getStart(), diagnosticsMessageSupplier);
+        assertEquals(new Position(25, 11), templateError.getRange().getEnd(), diagnosticsMessageSupplier);
+        assertTrue(templateError.getMessage().contains("The validation of a template overlay failed"), diagnosticsMessageSupplier);
         //the actual error
-        Diagnostic diagnostic = diagnostics.get(1);
-        assertEquals("ADL validation", diagnostic.getSource());
-        assertEquals(new Position(47, 12), diagnostic.getRange().getStart());
-        assertEquals(new Position(47, 19), diagnostic.getRange().getEnd());
-        assertTrue(diagnostic.getMessage().contains("Attribute CLUSTER.items cannot contain type DV_TEXT"));
+        Diagnostic templateOverlayError = diagnostics.get(1);
+        assertEquals("ADL validation", templateOverlayError.getSource(), diagnosticsMessageSupplier);
+        assertEquals(new Position(47, 12), templateOverlayError.getRange().getStart(), diagnosticsMessageSupplier);
+        assertEquals(new Position(47, 19), templateOverlayError.getRange().getEnd(), diagnosticsMessageSupplier);
+        assertTrue(templateOverlayError.getMessage().contains("Attribute CLUSTER.items cannot contain type DV_TEXT"), diagnosticsMessageSupplier);
     }
 
     /**
@@ -77,60 +69,58 @@ public class BasicTest extends LanguageServerTestBase {
     public void templateErrorElsewhere() throws IOException {
         openResource("test_archetype.adls");
         openResource("template_non_definition_error.adlt");
-        System.out.println(testClient.getDiagnostics());
+
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get("uri").getDiagnostics();
         assertFalse(diagnostics.isEmpty());
         //the error that one of the template overlay validations failed
         Diagnostic prettyMuchUselessError = diagnostics.get(0);
-        assertEquals("ADL validation", prettyMuchUselessError.getSource());
-        assertEquals(new Position(25, 4), prettyMuchUselessError.getRange().getStart());
-        assertEquals(new Position(25, 11), prettyMuchUselessError.getRange().getEnd());
-        assertTrue(prettyMuchUselessError.getMessage().contains("The validation of a template overlay failed"));
+        assertEquals("ADL validation", prettyMuchUselessError.getSource(), diagnosticsMessageSupplier);
+        assertEquals(new Position(25, 4), prettyMuchUselessError.getRange().getStart(), diagnosticsMessageSupplier);
+        assertEquals(new Position(25, 11), prettyMuchUselessError.getRange().getEnd(), diagnosticsMessageSupplier);
+        assertTrue(prettyMuchUselessError.getMessage().contains("The validation of a template overlay failed"), diagnosticsMessageSupplier);
         //the actual error
         Diagnostic diagnostic = diagnostics.get(1);
-        assertEquals("ADL validation", diagnostic.getSource());
-        assertEquals(new Position(39, 4), diagnostic.getRange().getStart());
-        assertEquals(new Position(39, 45), diagnostic.getRange().getEnd());
-        assertTrue(diagnostic.getMessage().contains("Id code qf1.1 in terminology is not a valid term code, should be id, ac or at, followed by digits"));
+        assertEquals("ADL validation", diagnostic.getSource(), diagnosticsMessageSupplier);
+        assertEquals(new Position(39, 4), diagnostic.getRange().getStart(), diagnosticsMessageSupplier);
+        assertEquals(new Position(39, 45), diagnostic.getRange().getEnd(), diagnosticsMessageSupplier);
+        assertTrue(diagnostic.getMessage().contains("Id code qf1.1 in terminology is not a valid term code, should be id, ac or at, followed by digits"), diagnosticsMessageSupplier);
     }
 
     @Test
     public void validationError() throws IOException {
-
         openResource("validation_error.adls");
-        System.out.println(testClient.getDiagnostics());
+
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get("uri").getDiagnostics();
-        assertFalse(diagnostics.isEmpty());
+        assertFalse(diagnostics.isEmpty(), diagnosticsMessageSupplier);
         Diagnostic diagnostic = diagnostics.get(0);
-        assertEquals(DiagnosticSeverity.Error, diagnostic.getSeverity());
-        assertEquals("ADL validation", diagnostic.getSource());
-        assertEquals(new Position(21, 20), diagnostic.getRange().getStart());
-        assertEquals(new Position(21, 25), diagnostic.getRange().getEnd());
+        assertEquals(DiagnosticSeverity.Error, diagnostic.getSeverity(), diagnosticsMessageSupplier);
+        assertEquals("ADL validation", diagnostic.getSource(), diagnosticsMessageSupplier);
+        assertEquals(new Position(21, 20), diagnostic.getRange().getStart(), diagnosticsMessageSupplier);
+        assertEquals(new Position(21, 25), diagnostic.getRange().getEnd(), diagnosticsMessageSupplier);
         assertTrue(diagnostic.getMessage().contains("WRONG"));
         assertTrue(diagnostic.getCode().getLeft().contains("VCORM"));
     }
 
     @Test
     public void jsonError() throws IOException {
-
         openResource("json_error.adls");
-        System.out.println(testClient.getDiagnostics());
+
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get("uri").getDiagnostics();
-        assertFalse(diagnostics.isEmpty());
+        assertFalse(diagnostics.isEmpty(), diagnosticsMessageSupplier);
         Diagnostic diagnostic = diagnostics.get(0);
-        assertEquals(DiagnosticSeverity.Error, diagnostic.getSeverity());
-        assertEquals("Error processing file", diagnostic.getSource());
-        assertEquals(new Position(0, 1), diagnostic.getRange().getStart());
-        assertEquals(new Position(0, 50), diagnostic.getRange().getEnd());
-        assertTrue(diagnostic.getMessage().contains("com.fasterxml.jackson.databind.JsonMappingException"));
+        assertEquals(DiagnosticSeverity.Error, diagnostic.getSeverity(), diagnosticsMessageSupplier);
+        assertEquals("Error processing file", diagnostic.getSource(), diagnosticsMessageSupplier);
+        assertEquals(new Position(0, 1), diagnostic.getRange().getStart(), diagnosticsMessageSupplier);
+        assertEquals(new Position(0, 50), diagnostic.getRange().getEnd(), diagnosticsMessageSupplier);
+        assertTrue(diagnostic.getMessage().contains("com.fasterxml.jackson.databind.JsonMappingException"), diagnosticsMessageSupplier);
     }
 
     @Test
     public void adl14() throws Exception {
         openResource("adl14_valid.adl");
-        System.out.println(testClient.getDiagnostics());
+
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get("uri").getDiagnostics();
-        assertTrue(diagnostics.isEmpty());
+        assertTrue(diagnostics.isEmpty(), diagnosticsMessageSupplier);
         CompletableFuture<List<Either<Command, CodeAction>>> codeActionsFuture = adl2LanguageServer.getTextDocumentService().codeAction(new CodeActionParams(new TextDocumentIdentifier("uri"), new Range(new Position(1, 1), new Position(1, 1)), new CodeActionContext()));
         List<Either<Command, CodeAction>> codeActions = codeActionsFuture.get();
         System.out.println(codeActions);
@@ -148,9 +138,9 @@ public class BasicTest extends LanguageServerTestBase {
 
         didOpenTextDocumentParams.setTextDocument(new TextDocumentItem("uri", "ADL", 1, archetype));
         textDocumentService.didOpen(didOpenTextDocumentParams);
-        System.out.println(testClient.getDiagnostics());
+
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get("uri").getDiagnostics();
-        assertTrue(diagnostics.isEmpty());
+        assertTrue(diagnostics.isEmpty(), diagnosticsMessageSupplier);
         CompletableFuture<List<Either<Command, CodeAction>>> codeActionsFuture = adl2LanguageServer.getTextDocumentService().codeAction(new CodeActionParams(new TextDocumentIdentifier("uri"), new Range(new Position(1, 1), new Position(1, 1)), new CodeActionContext()));
         List<Either<Command, CodeAction>> codeActions = codeActionsFuture.get();
         System.out.println(codeActions);
@@ -169,9 +159,9 @@ public class BasicTest extends LanguageServerTestBase {
 
         didOpenTextDocumentParams.setTextDocument(new TextDocumentItem("uri", "ADL", 1, archetype));
         textDocumentService.didOpen(didOpenTextDocumentParams);
-        System.out.println(testClient.getDiagnostics());
+
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get("uri").getDiagnostics();
-        assertTrue(diagnostics.isEmpty());
+        assertTrue(diagnostics.isEmpty(), diagnosticsMessageSupplier);
         CompletableFuture<List<Either<Command, CodeAction>>> codeActionsFuture = adl2LanguageServer.getTextDocumentService().codeAction(new CodeActionParams(new TextDocumentIdentifier("uri"), new Range(new Position(1, 1), new Position(1, 1)), new CodeActionContext()));
         List<Either<Command, CodeAction>> codeActions = codeActionsFuture.get();
         System.out.println(codeActions);

--- a/src/test/java/com/nedap/openehr/lsp/BasicTest.java
+++ b/src/test/java/com/nedap/openehr/lsp/BasicTest.java
@@ -10,7 +10,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -19,8 +18,7 @@ public class BasicTest extends LanguageServerTestBase {
     @Test
     public void testBasics() throws IOException {
         openResource("test_archetype.adls");
-        Supplier<String> messageSupplier = () -> testClient.getDiagnostics().toString();
-        assertTrue(testClient.getDiagnostics().get("uri").getDiagnostics().isEmpty(), messageSupplier);
+        assertTrue(testClient.getDiagnostics().get("uri").getDiagnostics().isEmpty(), diagnosticsMessageSupplier);
     }
 
     @Test

--- a/src/test/java/com/nedap/openehr/lsp/BasicTest.java
+++ b/src/test/java/com/nedap/openehr/lsp/BasicTest.java
@@ -30,10 +30,6 @@ public class BasicTest extends LanguageServerTestBase {
         assertTrue(testClient.getDiagnostics().get("uri").getDiagnostics().isEmpty());
     }
 
-
-
-
-
     @Test
     public void syntaxError() throws IOException {
 
@@ -46,6 +42,56 @@ public class BasicTest extends LanguageServerTestBase {
         assertEquals(new Position(17, 18), diagnostic.getRange().getStart());
         assertEquals(new Position(17, 53), diagnostic.getRange().getEnd());
         assertTrue(diagnostic.getMessage().contains("matchess"));
+    }
+
+    /**
+     * test that a template error gets syntax highlighting at the correct range
+     * @throws IOException
+     */
+    @Test
+    public void templateErrorInDefinition() throws IOException {
+        openResource("test_archetype.adls");
+        openResource("template_definition_error_in_ovl.adlt");
+        System.out.println(testClient.getDiagnostics());
+        List<Diagnostic> diagnostics = testClient.getDiagnostics().get("uri").getDiagnostics();
+        assertFalse(diagnostics.isEmpty());
+        //the error that one of the template overlay validations failed
+        Diagnostic prettyMuchUselessError = diagnostics.get(0);
+        assertEquals("ADL validation", prettyMuchUselessError.getSource());
+        assertEquals(new Position(25, 4), prettyMuchUselessError.getRange().getStart());
+        assertEquals(new Position(25, 11), prettyMuchUselessError.getRange().getEnd());
+        assertTrue(prettyMuchUselessError.getMessage().contains("The validation of a template overlay failed"));
+        //the actual error
+        Diagnostic diagnostic = diagnostics.get(1);
+        assertEquals("ADL validation", diagnostic.getSource());
+        assertEquals(new Position(47, 12), diagnostic.getRange().getStart());
+        assertEquals(new Position(47, 19), diagnostic.getRange().getEnd());
+        assertTrue(diagnostic.getMessage().contains("Attribute CLUSTER.items cannot contain type DV_TEXT"));
+    }
+
+    /**
+     * test that a template error gets syntax highlighting at the correct range
+     * @throws IOException
+     */
+    @Test
+    public void templateErrorElsewhere() throws IOException {
+        openResource("test_archetype.adls");
+        openResource("template_non_definition_error.adlt");
+        System.out.println(testClient.getDiagnostics());
+        List<Diagnostic> diagnostics = testClient.getDiagnostics().get("uri").getDiagnostics();
+        assertFalse(diagnostics.isEmpty());
+        //the error that one of the template overlay validations failed
+        Diagnostic prettyMuchUselessError = diagnostics.get(0);
+        assertEquals("ADL validation", prettyMuchUselessError.getSource());
+        assertEquals(new Position(25, 4), prettyMuchUselessError.getRange().getStart());
+        assertEquals(new Position(25, 11), prettyMuchUselessError.getRange().getEnd());
+        assertTrue(prettyMuchUselessError.getMessage().contains("The validation of a template overlay failed"));
+        //the actual error
+        Diagnostic diagnostic = diagnostics.get(1);
+        assertEquals("ADL validation", diagnostic.getSource());
+        assertEquals(new Position(39, 4), diagnostic.getRange().getStart());
+        assertEquals(new Position(39, 45), diagnostic.getRange().getEnd());
+        assertTrue(diagnostic.getMessage().contains("Id code qf1.1 in terminology is not a valid term code, should be id, ac or at, followed by digits"));
     }
 
     @Test

--- a/src/test/java/com/nedap/openehr/lsp/LanguageServerTestBase.java
+++ b/src/test/java/com/nedap/openehr/lsp/LanguageServerTestBase.java
@@ -11,16 +11,19 @@ import org.junit.jupiter.api.BeforeEach;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
 
 public abstract class LanguageServerTestBase {
 
     protected TestClient testClient;
     protected ADL2LanguageServer adl2LanguageServer;
     protected TextDocumentService textDocumentService;
+    protected Supplier<String> diagnosticsMessageSupplier;
 
     @BeforeEach
     public void setup() {
         testClient = new TestClient();
+        diagnosticsMessageSupplier = () -> testClient.getDiagnostics().toString();
         adl2LanguageServer = new ADL2LanguageServer();
         adl2LanguageServer.connect(testClient, null);
         InitializeParams initializeParams = new InitializeParams();

--- a/src/test/resources/com/nedap/openehr/lsp/template_definition_error_in_ovl.adlt
+++ b/src/test/resources/com/nedap/openehr/lsp/template_definition_error_in_ovl.adlt
@@ -1,0 +1,64 @@
+template (adl_version=2.0.5; rm_release=1.0.4; generated)
+    openEHR-EHR-CLUSTER.test_template.v0.1.2
+
+specialize
+    openEHR-EHR-CLUSTER.simple_sum.v0
+
+
+language
+    original_language = <[ISO_639-1::nl]>
+
+
+description
+    original_author = <
+        ["name"] = <"Pieter Bos">
+    >
+    lifecycle_state = <"DRAFT">
+    details = <
+        ["nl"] = <
+            language = <[ISO_639-1::nl]>
+            purpose = <"Een prachtige test-archetype">
+        >
+    >
+
+
+definition
+    CLUSTER[id1.1]
+
+terminology
+    term_definitions = <
+        ["nl"] = <
+            ["id1.1"] = <
+                text = <"test template">
+                description = <"test template">
+            >
+        >
+    >
+
+------------------------------------------------------------------------
+template_overlay
+    openEHR-EHR-CLUSTER.simple_sum-ovl.v0.0.1
+
+specialize
+    openEHR-EHR-CLUSTER.simple_sum.v0
+
+definition
+    CLUSTER[id1.1] matches {
+        items matches {
+            DV_TEXT[id0.5]
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["nl"] = <
+            ["id1.1"] = <
+                text = <"test template">
+                description = <"test template">
+            >
+            ["id0.5"] = <
+                text = <"test template">
+                description = <"test template">
+            >
+        >
+    >

--- a/src/test/resources/com/nedap/openehr/lsp/template_non_definition_error.adlt
+++ b/src/test/resources/com/nedap/openehr/lsp/template_non_definition_error.adlt
@@ -1,0 +1,60 @@
+template (adl_version=2.0.5; rm_release=1.0.4; generated)
+    openEHR-EHR-CLUSTER.test_template.v0.1.2
+
+specialize
+    openEHR-EHR-CLUSTER.simple_sum.v0
+
+
+language
+    original_language = <[ISO_639-1::nl]>
+
+
+description
+    original_author = <
+        ["name"] = <"Pieter Bos">
+    >
+    lifecycle_state = <"DRAFT">
+    details = <
+        ["nl"] = <
+            language = <[ISO_639-1::nl]>
+            purpose = <"Een prachtige test-archetype">
+        >
+    >
+
+
+definition
+    CLUSTER[id1.1]
+
+terminology
+    term_definitions = <
+        ["nl"] = <
+            ["id1.1"] = <
+                text = <"test template">
+                description = <"test template">
+            >
+        >
+    >
+
+------------------------------------------------------------------------
+template_overlay
+    openEHR-EHR-CLUSTER.simple_sum-ovl.v0.0.1
+
+specialize
+    openEHR-EHR-CLUSTER.simple_sum.v0
+
+definition
+    CLUSTER[id1.1]
+
+terminology
+    term_definitions = <
+        ["nl"] = <
+            ["id1.1"] = <
+                text = <"test template">
+                description = <"test template">
+            >
+            ["qf1.1"] = <
+                text = <"test template">
+                description = <"test template">
+            >
+        >
+    >


### PR DESCRIPTION
It now shows a diagnostic at the correct place in the file, which is either:

- the exact point of the error, in case of an error in the definition section that can be found
- the nearest point in the tree pointing towards the problem, in case of an error in the definition section that cannot be found
- the template_overlay token in the file.

In addition, it now shows in the diagnostics message for which overlay the validation message is

TODO:
- [x] test with a test build of the extension, rather than just a junit test