### PR TITLE
Suggestion: Create enum for Archetype files in test resource

### DIFF
--- a/src/test/java/com/nedap/openehr/lsp/BasicTest.java
+++ b/src/test/java/com/nedap/openehr/lsp/BasicTest.java
@@ -26,7 +26,7 @@ public class BasicTest extends LanguageServerTestBase {
     @Test
     public void testBasics() throws IOException {
 
-        openResource(TEST_ARCHETYPE_ADLS.getFilename());
+        openResource(TEST_ARCHETYPE_ADLS);
         System.out.println(testClient.getDiagnostics());
         assertTrue(testClient.getDiagnostics().get(TEST_ARCHETYPE_ADLS.getFilename()).getDiagnostics().isEmpty());
     }
@@ -34,7 +34,7 @@ public class BasicTest extends LanguageServerTestBase {
     @Test
     public void syntaxError() throws IOException {
 
-        openResource(SYNTAX_ERROR_ADLS.getFilename());
+        openResource(SYNTAX_ERROR_ADLS);
         System.out.println(testClient.getDiagnostics());
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get(SYNTAX_ERROR_ADLS.getFilename()).getDiagnostics();
         assertFalse(diagnostics.isEmpty());
@@ -51,8 +51,8 @@ public class BasicTest extends LanguageServerTestBase {
      */
     @Test
     public void templateErrorInDefinition() throws IOException {
-        openResource(TEST_ARCHETYPE_ADLS.getFilename());
-        openResource(TEMPLATE_DEFINITION_ERROR_IN_OVL_ADLT.getFilename());
+        openResource(TEST_ARCHETYPE_ADLS);
+        openResource(TEMPLATE_DEFINITION_ERROR_IN_OVL_ADLT);
         System.out.println(testClient.getDiagnostics());
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get(TEMPLATE_DEFINITION_ERROR_IN_OVL_ADLT.getFilename()).getDiagnostics();
         assertFalse(diagnostics.isEmpty());
@@ -76,8 +76,8 @@ public class BasicTest extends LanguageServerTestBase {
      */
     @Test
     public void templateErrorElsewhere() throws IOException {
-        openResource(TEST_ARCHETYPE_ADLS.getFilename());
-        openResource(TEMPLATE_NON_DEFINITION_ERROR_ADLT.getFilename());
+        openResource(TEST_ARCHETYPE_ADLS);
+        openResource(TEMPLATE_NON_DEFINITION_ERROR_ADLT);
         System.out.println(testClient.getDiagnostics());
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get(TEMPLATE_NON_DEFINITION_ERROR_ADLT.getFilename()).getDiagnostics();
         assertFalse(diagnostics.isEmpty());
@@ -98,7 +98,7 @@ public class BasicTest extends LanguageServerTestBase {
     @Test
     public void validationError() throws IOException {
 
-        openResource(VALIDATION_ERROR_ADLS.getFilename());
+        openResource(VALIDATION_ERROR_ADLS);
         System.out.println(testClient.getDiagnostics());
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get(VALIDATION_ERROR_ADLS.getFilename()).getDiagnostics();
         assertFalse(diagnostics.isEmpty());
@@ -114,7 +114,7 @@ public class BasicTest extends LanguageServerTestBase {
     @Test
     public void jsonError() throws IOException {
 
-        openResource(JSON_ERROR_ADLS.getFilename());
+        openResource(JSON_ERROR_ADLS);
         System.out.println(testClient.getDiagnostics());
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get(JSON_ERROR_ADLS.getFilename()).getDiagnostics();
         assertFalse(diagnostics.isEmpty());
@@ -128,7 +128,7 @@ public class BasicTest extends LanguageServerTestBase {
 
     @Test
     public void adl14() throws Exception {
-        openResource(ADL14_VALID_ADL.getFilename());
+        openResource(ADL14_VALID_ADL);
         System.out.println(testClient.getDiagnostics());
         List<Diagnostic> diagnostics = testClient.getDiagnostics().get(ADL14_VALID_ADL.getFilename()).getDiagnostics();
         assertTrue(diagnostics.isEmpty());

--- a/src/test/java/com/nedap/openehr/lsp/BasicTest.java
+++ b/src/test/java/com/nedap/openehr/lsp/BasicTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import static com.nedap.openehr.lsp.TestArchetypes.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class BasicTest extends LanguageServerTestBase {
@@ -25,17 +26,17 @@ public class BasicTest extends LanguageServerTestBase {
     @Test
     public void testBasics() throws IOException {
 
-        openResource("test_archetype.adls");
+        openResource(TEST_ARCHETYPE_ADLS.getFilename());
         System.out.println(testClient.getDiagnostics());
-        assertTrue(testClient.getDiagnostics().get("test_archetype.adls").getDiagnostics().isEmpty());
+        assertTrue(testClient.getDiagnostics().get(TEST_ARCHETYPE_ADLS.getFilename()).getDiagnostics().isEmpty());
     }
 
     @Test
     public void syntaxError() throws IOException {
 
-        openResource("syntax_error.adls");
+        openResource(SYNTAX_ERROR_ADLS.getFilename());
         System.out.println(testClient.getDiagnostics());
-        List<Diagnostic> diagnostics = testClient.getDiagnostics().get("syntax_error.adls").getDiagnostics();
+        List<Diagnostic> diagnostics = testClient.getDiagnostics().get(SYNTAX_ERROR_ADLS.getFilename()).getDiagnostics();
         assertFalse(diagnostics.isEmpty());
         Diagnostic diagnostic = diagnostics.get(0);
         assertEquals("ADL2 syntax", diagnostic.getSource());
@@ -50,10 +51,10 @@ public class BasicTest extends LanguageServerTestBase {
      */
     @Test
     public void templateErrorInDefinition() throws IOException {
-        openResource("test_archetype.adls");
-        openResource("template_definition_error_in_ovl.adlt");
+        openResource(TEST_ARCHETYPE_ADLS.getFilename());
+        openResource(TEMPLATE_DEFINITION_ERROR_IN_OVL_ADLT.getFilename());
         System.out.println(testClient.getDiagnostics());
-        List<Diagnostic> diagnostics = testClient.getDiagnostics().get("template_definition_error_in_ovl.adlt").getDiagnostics();
+        List<Diagnostic> diagnostics = testClient.getDiagnostics().get(TEMPLATE_DEFINITION_ERROR_IN_OVL_ADLT.getFilename()).getDiagnostics();
         assertFalse(diagnostics.isEmpty());
         //the error that one of the template overlay validations failed
         Diagnostic prettyMuchUselessError = diagnostics.get(0);
@@ -75,10 +76,10 @@ public class BasicTest extends LanguageServerTestBase {
      */
     @Test
     public void templateErrorElsewhere() throws IOException {
-        openResource("test_archetype.adls");
-        openResource("template_non_definition_error.adlt");
+        openResource(TEST_ARCHETYPE_ADLS.getFilename());
+        openResource(TEMPLATE_NON_DEFINITION_ERROR_ADLT.getFilename());
         System.out.println(testClient.getDiagnostics());
-        List<Diagnostic> diagnostics = testClient.getDiagnostics().get("template_non_definition_error.adlt").getDiagnostics();
+        List<Diagnostic> diagnostics = testClient.getDiagnostics().get(TEMPLATE_NON_DEFINITION_ERROR_ADLT.getFilename()).getDiagnostics();
         assertFalse(diagnostics.isEmpty());
         //the error that one of the template overlay validations failed
         Diagnostic prettyMuchUselessError = diagnostics.get(0);
@@ -97,9 +98,9 @@ public class BasicTest extends LanguageServerTestBase {
     @Test
     public void validationError() throws IOException {
 
-        openResource("validation_error.adls");
+        openResource(VALIDATION_ERROR_ADLS.getFilename());
         System.out.println(testClient.getDiagnostics());
-        List<Diagnostic> diagnostics = testClient.getDiagnostics().get("validation_error.adls").getDiagnostics();
+        List<Diagnostic> diagnostics = testClient.getDiagnostics().get(VALIDATION_ERROR_ADLS.getFilename()).getDiagnostics();
         assertFalse(diagnostics.isEmpty());
         Diagnostic diagnostic = diagnostics.get(0);
         assertEquals(DiagnosticSeverity.Error, diagnostic.getSeverity());
@@ -113,9 +114,9 @@ public class BasicTest extends LanguageServerTestBase {
     @Test
     public void jsonError() throws IOException {
 
-        openResource("json_error.adls");
+        openResource(JSON_ERROR_ADLS.getFilename());
         System.out.println(testClient.getDiagnostics());
-        List<Diagnostic> diagnostics = testClient.getDiagnostics().get("json_error.adls").getDiagnostics();
+        List<Diagnostic> diagnostics = testClient.getDiagnostics().get(JSON_ERROR_ADLS.getFilename()).getDiagnostics();
         assertFalse(diagnostics.isEmpty());
         Diagnostic diagnostic = diagnostics.get(0);
         assertEquals(DiagnosticSeverity.Error, diagnostic.getSeverity());
@@ -127,9 +128,9 @@ public class BasicTest extends LanguageServerTestBase {
 
     @Test
     public void adl14() throws Exception {
-        openResource("adl14_valid.adl");
+        openResource(ADL14_VALID_ADL.getFilename());
         System.out.println(testClient.getDiagnostics());
-        List<Diagnostic> diagnostics = testClient.getDiagnostics().get("adl14_valid.adl").getDiagnostics();
+        List<Diagnostic> diagnostics = testClient.getDiagnostics().get(ADL14_VALID_ADL.getFilename()).getDiagnostics();
         assertTrue(diagnostics.isEmpty());
         CompletableFuture<List<Either<Command, CodeAction>>> codeActionsFuture = adl2LanguageServer.getTextDocumentService().codeAction(new CodeActionParams(new TextDocumentIdentifier("adl14_valid.adl"), new Range(new Position(1, 1), new Position(1, 1)), new CodeActionContext()));
         List<Either<Command, CodeAction>> codeActions = codeActionsFuture.get();
@@ -141,15 +142,15 @@ public class BasicTest extends LanguageServerTestBase {
     public void adl14WindowsFileEndings() throws Exception {
         DidOpenTextDocumentParams didOpenTextDocumentParams = new DidOpenTextDocumentParams();
         String archetype;
-        try (InputStream stream = getClass().getResourceAsStream("adl14_valid.adl")) {
+        try (InputStream stream = getClass().getResourceAsStream(ADL14_VALID_ADL.getFilename())) {
             archetype = IOUtils.toString(stream, StandardCharsets.UTF_8.name());
         }
         archetype = ensureWindowsLineEndings(archetype);
 
-        didOpenTextDocumentParams.setTextDocument(new TextDocumentItem("adl14_valid.adl", "ADL", 1, archetype));
+        didOpenTextDocumentParams.setTextDocument(new TextDocumentItem(ADL14_VALID_ADL.getFilename(), "ADL", 1, archetype));
         textDocumentService.didOpen(didOpenTextDocumentParams);
         System.out.println(testClient.getDiagnostics());
-        List<Diagnostic> diagnostics = testClient.getDiagnostics().get("adl14_valid.adl").getDiagnostics();
+        List<Diagnostic> diagnostics = testClient.getDiagnostics().get(ADL14_VALID_ADL.getFilename()).getDiagnostics();
         assertTrue(diagnostics.isEmpty());
         CompletableFuture<List<Either<Command, CodeAction>>> codeActionsFuture = adl2LanguageServer.getTextDocumentService().codeAction(new CodeActionParams(new TextDocumentIdentifier("adl14_valid.adl"), new Range(new Position(1, 1), new Position(1, 1)), new CodeActionContext()));
         List<Either<Command, CodeAction>> codeActions = codeActionsFuture.get();
@@ -162,17 +163,19 @@ public class BasicTest extends LanguageServerTestBase {
     public void adl14LinuxFileEndings() throws Exception {
         DidOpenTextDocumentParams didOpenTextDocumentParams = new DidOpenTextDocumentParams();
         String archetype;
-        try (InputStream stream = getClass().getResourceAsStream("adl14_valid.adl")) {
+        try (InputStream stream = getClass().getResourceAsStream(ADL14_VALID_ADL.getFilename())) {
             archetype = IOUtils.toString(stream, StandardCharsets.UTF_8.name());
         }
         archetype = normalizeLineEndings(archetype);
 
-        didOpenTextDocumentParams.setTextDocument(new TextDocumentItem("adl14_valid.adl", "ADL", 1, archetype));
+        didOpenTextDocumentParams.setTextDocument(new TextDocumentItem(ADL14_VALID_ADL.getFilename(), "ADL", 1, archetype));
         textDocumentService.didOpen(didOpenTextDocumentParams);
         System.out.println(testClient.getDiagnostics());
-        List<Diagnostic> diagnostics = testClient.getDiagnostics().get("adl14_valid.adl").getDiagnostics();
+        List<Diagnostic> diagnostics = testClient.getDiagnostics().get(ADL14_VALID_ADL.getFilename()).getDiagnostics();
         assertTrue(diagnostics.isEmpty());
-        CompletableFuture<List<Either<Command, CodeAction>>> codeActionsFuture = adl2LanguageServer.getTextDocumentService().codeAction(new CodeActionParams(new TextDocumentIdentifier("adl14_valid.adl"), new Range(new Position(1, 1), new Position(1, 1)), new CodeActionContext()));
+        CompletableFuture<List<Either<Command, CodeAction>>> codeActionsFuture = adl2LanguageServer
+                .getTextDocumentService().codeAction(new CodeActionParams(new TextDocumentIdentifier(ADL14_VALID_ADL.getFilename()),
+                        new Range(new Position(1, 1), new Position(1, 1)), new CodeActionContext()));
         List<Either<Command, CodeAction>> codeActions = codeActionsFuture.get();
         System.out.println(codeActions);
         assertEquals(2, codeActions.size());

--- a/src/test/java/com/nedap/openehr/lsp/DocumentOutlineTest.java
+++ b/src/test/java/com/nedap/openehr/lsp/DocumentOutlineTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import static com.nedap.openehr.lsp.TestArchetypes.TEST_ARCHETYPE_ADLS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DocumentOutlineTest extends LanguageServerTestBase {
@@ -24,8 +25,9 @@ public class DocumentOutlineTest extends LanguageServerTestBase {
     @Test
     public void testDocumentOutline() throws IOException, ExecutionException, InterruptedException {
 
-        openResource("test_archetype.adls");
-        CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> uri = adl2LanguageServer.getTextDocumentService().documentSymbol(new DocumentSymbolParams(new TextDocumentIdentifier("test_archetype.adls")));
+        openResource(TEST_ARCHETYPE_ADLS.getFilename());
+        CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> uri =
+                adl2LanguageServer.getTextDocumentService().documentSymbol(new DocumentSymbolParams(new TextDocumentIdentifier(TEST_ARCHETYPE_ADLS.getFilename())));
         List<Either<SymbolInformation, DocumentSymbol>> eitherSymbols = uri.get();
         List<DocumentSymbol> documentSymbols = DocumentSymbolUtils.getDocumentSymbols(eitherSymbols);
         //System.out.println(documentSymbols);

--- a/src/test/java/com/nedap/openehr/lsp/DocumentOutlineTest.java
+++ b/src/test/java/com/nedap/openehr/lsp/DocumentOutlineTest.java
@@ -25,7 +25,7 @@ public class DocumentOutlineTest extends LanguageServerTestBase {
     @Test
     public void testDocumentOutline() throws IOException, ExecutionException, InterruptedException {
 
-        openResource(TEST_ARCHETYPE_ADLS.getFilename());
+        openResource(TEST_ARCHETYPE_ADLS);
         CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> uri =
                 adl2LanguageServer.getTextDocumentService().documentSymbol(new DocumentSymbolParams(new TextDocumentIdentifier(TEST_ARCHETYPE_ADLS.getFilename())));
         List<Either<SymbolInformation, DocumentSymbol>> eitherSymbols = uri.get();

--- a/src/test/java/com/nedap/openehr/lsp/FoldingRangesTest.java
+++ b/src/test/java/com/nedap/openehr/lsp/FoldingRangesTest.java
@@ -10,14 +10,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import static com.nedap.openehr.lsp.TestArchetypes.TEST_ARCHETYPE_ADLS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FoldingRangesTest extends LanguageServerTestBase {
 
     @Test
     public void testFoldingRanges() throws Exception {
-        openResource("test_archetype.adls");
-        List<FoldingRange> foldingRanges = adl2LanguageServer.getTextDocumentService().foldingRange(new FoldingRangeRequestParams(new TextDocumentIdentifier("test_archetype.adls"))).get();
+        openResource(TEST_ARCHETYPE_ADLS.getFilename());
+        List<FoldingRange> foldingRanges = adl2LanguageServer.getTextDocumentService().foldingRange(
+                new FoldingRangeRequestParams(new TextDocumentIdentifier(TEST_ARCHETYPE_ADLS.getFilename()))).get();
         System.out.println(foldingRanges);
         List<FoldingRange> expected = new ArrayList<>();
         expected.add(new FoldingRange(3, 4)); //language section
@@ -41,5 +43,4 @@ public class FoldingRangesTest extends LanguageServerTestBase {
 
         assertEquals(expected, foldingRanges.subList(0, expected.size()));
     }
-
 }

--- a/src/test/java/com/nedap/openehr/lsp/FoldingRangesTest.java
+++ b/src/test/java/com/nedap/openehr/lsp/FoldingRangesTest.java
@@ -17,7 +17,7 @@ public class FoldingRangesTest extends LanguageServerTestBase {
 
     @Test
     public void testFoldingRanges() throws Exception {
-        openResource(TEST_ARCHETYPE_ADLS.getFilename());
+        openResource(TEST_ARCHETYPE_ADLS);
         List<FoldingRange> foldingRanges = adl2LanguageServer.getTextDocumentService().foldingRange(
                 new FoldingRangeRequestParams(new TextDocumentIdentifier(TEST_ARCHETYPE_ADLS.getFilename()))).get();
         System.out.println(foldingRanges);

--- a/src/test/java/com/nedap/openehr/lsp/LanguageServerTestBase.java
+++ b/src/test/java/com/nedap/openehr/lsp/LanguageServerTestBase.java
@@ -33,11 +33,12 @@ public abstract class LanguageServerTestBase {
         textDocumentService = adl2LanguageServer.getTextDocumentService();
     }
 
-    protected void openResource(String filename) throws IOException {
+    protected void openResource(TestArchetypes file) throws IOException {
         DidOpenTextDocumentParams didOpenTextDocumentParams = new DidOpenTextDocumentParams();
+        String filename = file.getFilename();
         String archetype;
         try (InputStream stream = getClass().getResourceAsStream(filename)) {
-            archetype = IOUtils.toString(stream, StandardCharsets.UTF_8.name());
+            archetype = IOUtils.toString(stream, StandardCharsets.UTF_8);
         }
 
         didOpenTextDocumentParams.setTextDocument(new TextDocumentItem(filename, "ADL", 1, archetype));

--- a/src/test/java/com/nedap/openehr/lsp/RulesCodeLensTest.java
+++ b/src/test/java/com/nedap/openehr/lsp/RulesCodeLensTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import static com.nedap.openehr.lsp.TestArchetypes.ARCHETYPE_WITH_RULES_ADLS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RulesCodeLensTest extends LanguageServerTestBase {
@@ -15,9 +16,10 @@ public class RulesCodeLensTest extends LanguageServerTestBase {
     @Test
     public void testRulesCodeLens() throws IOException, ExecutionException, InterruptedException {
 
-        openResource("archetype_with_rules.adls");
+        openResource(ARCHETYPE_WITH_RULES_ADLS.getFilename());
         System.out.println(testClient.getDiagnostics());
-        CompletableFuture<List<? extends CodeLens>> uri = adl2LanguageServer.getTextDocumentService().codeLens(new CodeLensParams(new TextDocumentIdentifier("archetype_with_rules.adls")));
+        CompletableFuture<List<? extends CodeLens>> uri = adl2LanguageServer.getTextDocumentService().codeLens(
+                new CodeLensParams(new TextDocumentIdentifier(ARCHETYPE_WITH_RULES_ADLS.getFilename())));
         List<? extends CodeLens> codeLens = uri.get();
         assertEquals(2, codeLens.size());
         CodeLens lens1 = codeLens.get(0);
@@ -29,7 +31,8 @@ public class RulesCodeLensTest extends LanguageServerTestBase {
         assertEquals(new Range(new Position(37, 62), new Position(37,73)), lens2.getRange());
         assertEquals("Element 2\n\nIn Archetype A test cluster (openEHR-EHR-CLUSTER.simple_sum.v0.0.1)", lens2.getCommand().getArguments().get(0));
 
-        CompletableFuture<Hover> hover = adl2LanguageServer.getTextDocumentService().hover(new HoverParams(new TextDocumentIdentifier("archetype_with_rules.adls"), new Position(37, 30)));
+        CompletableFuture<Hover> hover = adl2LanguageServer.getTextDocumentService().hover(
+                new HoverParams(new TextDocumentIdentifier(ARCHETYPE_WITH_RULES_ADLS.getFilename()), new Position(37, 30)));
         Hover hover1 = hover.get();
         assertEquals("markdown", hover1.getContents().getRight().getKind());
         assertEquals("Element 1/value/defining_code\n" +

--- a/src/test/java/com/nedap/openehr/lsp/RulesCodeLensTest.java
+++ b/src/test/java/com/nedap/openehr/lsp/RulesCodeLensTest.java
@@ -16,7 +16,7 @@ public class RulesCodeLensTest extends LanguageServerTestBase {
     @Test
     public void testRulesCodeLens() throws IOException, ExecutionException, InterruptedException {
 
-        openResource(ARCHETYPE_WITH_RULES_ADLS.getFilename());
+        openResource(ARCHETYPE_WITH_RULES_ADLS);
         System.out.println(testClient.getDiagnostics());
         CompletableFuture<List<? extends CodeLens>> uri = adl2LanguageServer.getTextDocumentService().codeLens(
                 new CodeLensParams(new TextDocumentIdentifier(ARCHETYPE_WITH_RULES_ADLS.getFilename())));

--- a/src/test/java/com/nedap/openehr/lsp/RunCommandTest.java
+++ b/src/test/java/com/nedap/openehr/lsp/RunCommandTest.java
@@ -16,8 +16,8 @@ public class RunCommandTest extends LanguageServerTestBase {
 
     @Test
     public void generateOpt() throws Exception {
-        openResource(TEST_ARCHETYPE_ADLS.getFilename());
-        openResource(CORRECT_TEMPLATE_ADLT.getFilename());
+        openResource(TEST_ARCHETYPE_ADLS);
+        openResource(CORRECT_TEMPLATE_ADLT);
         //check that the archetypes are correct
         assertTrue(testClient.getDiagnostics().get(TEST_ARCHETYPE_ADLS.getFilename()).getDiagnostics().isEmpty());
 
@@ -52,8 +52,8 @@ public class RunCommandTest extends LanguageServerTestBase {
 
     @Test
     public void generateExample() throws Exception {
-        openResource(TEST_ARCHETYPE_ADLS.getFilename());
-        openResource(CORRECT_TEMPLATE_ADLT.getFilename());
+        openResource(TEST_ARCHETYPE_ADLS);
+        openResource(CORRECT_TEMPLATE_ADLT);
 
         //check that the archetypes are correct
         assertTrue(testClient.getDiagnostics().get(CORRECT_TEMPLATE_ADLT.getFilename()).getDiagnostics().isEmpty());
@@ -87,7 +87,7 @@ public class RunCommandTest extends LanguageServerTestBase {
 
     @Test
     public void generateExampleForOpt() throws Exception {
-        openResource(CORRECT_OPT_OPT2.getFilename());
+        openResource(CORRECT_OPT_OPT2);
 
         //check that the archetypes are correct
         assertTrue(testClient.getDiagnostics().get(CORRECT_OPT_OPT2.getFilename()).getDiagnostics().isEmpty());

--- a/src/test/java/com/nedap/openehr/lsp/RunCommandTest.java
+++ b/src/test/java/com/nedap/openehr/lsp/RunCommandTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.nedap.openehr.lsp.TestArchetypes.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -15,13 +16,14 @@ public class RunCommandTest extends LanguageServerTestBase {
 
     @Test
     public void generateOpt() throws Exception {
-        openResource("test_archetype.adls");
-        openResource("correct_template.adlt");
+        openResource(TEST_ARCHETYPE_ADLS.getFilename());
+        openResource(CORRECT_TEMPLATE_ADLT.getFilename());
         //check that the archetypes are correct
-        assertTrue(testClient.getDiagnostics().get("test_archetype.adls").getDiagnostics().isEmpty());
+        assertTrue(testClient.getDiagnostics().get(TEST_ARCHETYPE_ADLS.getFilename()).getDiagnostics().isEmpty());
 
         assertTrue(initializeResult.getCapabilities().getExecuteCommandProvider().getCommands().contains("source.opt"));
-        List<Either<Command, CodeAction>> codeActions = textDocumentService.codeAction(new CodeActionParams(new TextDocumentIdentifier("correct_template.adlt"),
+        List<Either<Command, CodeAction>> codeActions = textDocumentService.codeAction(
+                new CodeActionParams(new TextDocumentIdentifier(CORRECT_TEMPLATE_ADLT.getFilename()),
                 new Range(new Position(1, 1), new Position(1, 15)),
                 new CodeActionContext())).get();
         System.out.println(codeActions);
@@ -50,14 +52,14 @@ public class RunCommandTest extends LanguageServerTestBase {
 
     @Test
     public void generateExample() throws Exception {
-        openResource("test_archetype.adls");
-        openResource("correct_template.adlt");
+        openResource(TEST_ARCHETYPE_ADLS.getFilename());
+        openResource(CORRECT_TEMPLATE_ADLT.getFilename());
 
         //check that the archetypes are correct
-        assertTrue(testClient.getDiagnostics().get("correct_template.adlt").getDiagnostics().isEmpty());
+        assertTrue(testClient.getDiagnostics().get(CORRECT_TEMPLATE_ADLT.getFilename()).getDiagnostics().isEmpty());
 
         assertTrue(initializeResult.getCapabilities().getExecuteCommandProvider().getCommands().contains("source.example"));
-        List<Either<Command, CodeAction>> listCompletableFuture = textDocumentService.codeAction(new CodeActionParams(new TextDocumentIdentifier("correct_template.adlt"),
+        List<Either<Command, CodeAction>> listCompletableFuture = textDocumentService.codeAction(new CodeActionParams(new TextDocumentIdentifier(CORRECT_TEMPLATE_ADLT.getFilename()),
                 new Range(new Position(1, 1), new Position(1, 15)),
                 new CodeActionContext())).get();
         CodeAction exampleAction = listCompletableFuture.stream().filter(c -> c.isRight() && c.getRight().getKind().equals("source.example.json")).findFirst().get().getRight();
@@ -85,13 +87,14 @@ public class RunCommandTest extends LanguageServerTestBase {
 
     @Test
     public void generateExampleForOpt() throws Exception {
-        openResource("correct_opt.opt2");
+        openResource(CORRECT_OPT_OPT2.getFilename());
 
         //check that the archetypes are correct
-        assertTrue(testClient.getDiagnostics().get("correct_opt.opt2").getDiagnostics().isEmpty());
+        assertTrue(testClient.getDiagnostics().get(CORRECT_OPT_OPT2.getFilename()).getDiagnostics().isEmpty());
 
         assertTrue(initializeResult.getCapabilities().getExecuteCommandProvider().getCommands().contains("source.example"));
-        List<Either<Command, CodeAction>> listCompletableFuture = textDocumentService.codeAction(new CodeActionParams(new TextDocumentIdentifier("correct_opt.opt2"),
+        List<Either<Command, CodeAction>> listCompletableFuture = textDocumentService.codeAction(
+                new CodeActionParams(new TextDocumentIdentifier(CORRECT_OPT_OPT2.getFilename()),
                 new Range(new Position(1, 1), new Position(1, 15)),
                 new CodeActionContext())).get();
         CodeAction exampleAction = listCompletableFuture.stream().filter(c -> c.isRight() && c.getRight().getKind().equals("source.example.json")).findFirst().get().getRight();

--- a/src/test/java/com/nedap/openehr/lsp/TestArchetypes.java
+++ b/src/test/java/com/nedap/openehr/lsp/TestArchetypes.java
@@ -1,0 +1,24 @@
+package com.nedap.openehr.lsp;
+
+public enum TestArchetypes {
+    ADL14_VALID_ADL("adl14_valid.adl"),
+    ARCHETYPE_WITH_RULES_ADLS("archetype_with_rules.adls"),
+    CORRECT_OPT_OPT2("correct_opt.opt2"),
+    CORRECT_TEMPLATE_ADLT("correct_template.adlt"),
+    JSON_ERROR_ADLS("json_error.adls"),
+    SYNTAX_ERROR_ADLS("syntax_error.adls"),
+    TEMPLATE_DEFINITION_ERROR_IN_OVL_ADLT("template_definition_error_in_ovl.adlt"),
+    TEMPLATE_NON_DEFINITION_ERROR_ADLT("template_non_definition_error.adlt"),
+    TEST_ARCHETYPE_ADLS("test_archetype.adls"),
+    VALIDATION_ERROR_ADLS("validation_error.adls");
+
+    private final String filename;
+
+    TestArchetypes(final String filename) {
+        this.filename = filename;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+}


### PR DESCRIPTION
extends #36 

Created enum TestArchetypes in test suite to facilitate filename calls.
All enum archetype files are within the test resources directory.