### PR TITLE
Update to Archie 3.0 and version number to 0.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,11 @@ repositories {
 }
 
 dependencies {
-    antlr group: 'org.antlr', name: 'antlr4', version: '4.9.3' //kept at 4.9.3 for now, update when Archie updates this
+    antlr group: 'org.antlr', name: 'antlr4', version: '4.11.1'
     // This dependency is used by the application.
     implementation 'com.google.guava:guava:31.1-jre'
 
-    implementation('com.nedap.healthcare.archie:archie-all:2.1.0')
+    implementation('com.nedap.healthcare.archie:archie-all:3.0.0')
     implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.19.0'
     implementation 'org.slf4j:slf4j-nop:1.7.36'
 

--- a/src/main/java/com/nedap/openehr/lsp/ADL2LanguageServer.java
+++ b/src/main/java/com/nedap/openehr/lsp/ADL2LanguageServer.java
@@ -62,7 +62,7 @@ public class ADL2LanguageServer implements LanguageServer {
 
         ServerInfo serverInfo = new ServerInfo();
         serverInfo.setName("ADL 2 Archetype language server");
-        serverInfo.setVersion("0.6.0");
+        serverInfo.setVersion("0.6.1");
         completableFuture.complete(new InitializeResult(capabilities, serverInfo));
         System.err.println(params.getRootUri());
         System.err.println(params.getWorkspaceFolders());

--- a/vscode-extension/client/package-lock.json
+++ b/vscode-extension/client/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "archetype-languageserver-vscode-client",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "archetype-languageserver-vscode-client",
-			"version": "0.6.0",
+			"version": "0.6.1",
 			"license": "Apache 2",
 			"dependencies": {
 				"vscode-languageclient": "^8.0.0"

--- a/vscode-extension/client/package.json
+++ b/vscode-extension/client/package.json
@@ -3,7 +3,7 @@
 	"description": "VSCode part of the OpenEHR language server",
 	"author": "Nedap Healthcare",
 	"license": "Apache 2",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"publisher": "vscode",
 	"repository": {
 		"type": "git",

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "openehr-adl-lsp",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "openehr-adl-lsp",
-			"version": "0.6.0",
+			"version": "0.6.1",
 			"hasInstallScript": true,
 			"license": "Apache 2.0",
 			"devDependencies": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -4,7 +4,7 @@
 	"description": "OpenEHR ADL support, including syntax highlighting and validation",
 	"author": "Nedap Healthcare",
 	"license": "Apache 2.0",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"icon": "openehr-square-256x256.png",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This should have been included in 0.6.0 of course - but I missed the Archie release. So, let's make a 0.6.1